### PR TITLE
Bump d2l-text-input to 0.6.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "d2l-localize-behavior": "^1.1.0",
     "d2l-menu": "^1.0.4",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^2.2.0",
-    "d2l-text-input": "BrightspaceUI/text-input#^0.5.0",
+    "d2l-text-input": "BrightspaceUI/text-input#^0.6.0",
     "d2l-tooltip": "^2.0.4",
     "d2l-tile": "^4.1.6",
     "d2l-typography": "BrightspaceUI/typography#^6.0.0",


### PR DESCRIPTION
Unfortunately minor versions do not get picked up automatically when the major version is `0`. @svanherk maybe when you move it to `d2l-input-text` consider starting the major versions at `1`