### PR TITLE
align version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/BrightspaceUI/d2l-my-dashboards-ui.git"
   },
-  "version": "2.0.1",
+  "version": "3.0.3",
   "name": "d2l-my-dashboards",
   "scripts": {
     "lint": "npm run lint:wc && npm run lint:js",


### PR DESCRIPTION
The version in `package.json` needs to match the tag version for the GitHub references to work correctly from BSI with newer versions of NPM. Once this merges, I'll create a `v3.0.3` tag to match it.