### PR TITLE
Add novalidate to d2l-input-text

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/BrightspaceUI/d2l-my-dashboards-ui.git"
   },
-  "version": "3.0.3",
+  "version": "3.0.4",
   "name": "d2l-my-dashboards",
   "scripts": {
     "lint": "npm run lint:wc && npm run lint:js",

--- a/src/d2l-dashboard-editor.js
+++ b/src/d2l-dashboard-editor.js
@@ -50,7 +50,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-dashboard-editor">
 
 			[[localize('dashboardDisplayNameLabel')]]
 
-			<d2l-input-text id="display-name-input" name="dashboardDisplayName" aria-invalid$="[[_boolToString(_invalidDisplayName)]]">
+			<d2l-input-text id="display-name-input" name="dashboardDisplayName" aria-invalid$="[[_boolToString(_invalidDisplayName)]]" novalidate>
 			</d2l-input-text>
 
 			<div class="dashboard-description">


### PR DESCRIPTION
**Context:**
`d2l-input-text` is getting live validation so it can validate itself. To prevent this from impacting places that have their own validation we're adding `novalidate`. This will keep the behavior unchanged.